### PR TITLE
feat: add exception message in the user interface

### DIFF
--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -56,6 +56,7 @@ from common.djangoapps.student.message_types import AccountActivation, EmailChan
 from common.djangoapps.student.models import (  # lint-amnesty, pylint: disable=unused-import
     AccountRecovery,
     CourseEnrollment,
+    EnrollmentNotAllowed,
     PendingEmailChange,  # unimport:skip
     PendingSecondaryEmailChange,
     Registration,
@@ -360,6 +361,8 @@ def change_enrollment(request, check_access=True):
                 enroll_mode = CourseMode.auto_enroll_mode(course_id, available_modes)
                 if enroll_mode:
                     CourseEnrollment.enroll(user, course_id, check_access=check_access, mode=enroll_mode)
+            except EnrollmentNotAllowed as exec:  # pylint: disable=broad-except
+                return HttpResponseBadRequest(str(exec))
             except Exception:  # pylint: disable=broad-except
                 return HttpResponseBadRequest(_("Could not enroll"))
 


### PR DESCRIPTION
## Description

This PR allows showing the exception message for the enrollment filter in the user interface.

## Screenshots

![Screenshot from 2022-09-26 13-30-46](https://user-images.githubusercontent.com/35668326/192400263-1eba37ce-ae2a-48fe-ae9d-56ecfa6c3400.png)
_User interface when user can't enroll (en)_
![Screenshot from 2022-09-26 13-31-05](https://user-images.githubusercontent.com/35668326/192400346-e4d5e104-5b6c-40c7-aa05-7a59746f0755.png)
_User interface when user can't enroll (pt-pt)_

## How to test

Review [nau-openedx-extensions PR #5](https://github.com/fccn/nau-openedx-extensions/pull/5)

## Other info

Change inspired by [edx-platform PR #29948](https://github.com/openedx/edx-platform/pull/29948/files)