### PR TITLE
fix(FAN-41): catch the EnrollmentNotAllowed and InvalidEnrollmentAttribute

### DIFF
--- a/openedx/core/djangoapps/enrollments/data.py
+++ b/openedx/core/djangoapps/enrollments/data.py
@@ -26,7 +26,8 @@ from common.djangoapps.student.models import (
     CourseEnrollmentAttribute,
     CourseFullError,
     EnrollmentClosedError,
-    NonExistentCourseError
+    NonExistentCourseError,
+    EnrollmentNotAllowed,
 )
 from common.djangoapps.student.roles import RoleCache
 
@@ -148,6 +149,8 @@ def create_course_enrollment(username, course_id, mode, is_active):
     try:
         enrollment = CourseEnrollment.enroll(user, course_key, check_access=True)
         return _update_enrollment(enrollment, is_active=is_active, mode=mode)
+    except EnrollmentNotAllowed as err:
+        raise InvalidEnrollmentAttribute(str(err))
     except NonExistentCourseError as err:
         raise CourseNotFoundError(str(err))  # lint-amnesty, pylint: disable=raise-missing-from
     except EnrollmentClosedError as err:

--- a/openedx/core/djangoapps/enrollments/views.py
+++ b/openedx/core/djangoapps/enrollments/views.py
@@ -20,7 +20,7 @@ from openedx.core.djangoapps.course_groups.cohorts import CourseUserGroup, add_u
 from openedx.core.djangoapps.embargo import api as embargo_api
 from openedx.core.djangoapps.enrollments import api
 from openedx.core.djangoapps.enrollments.errors import (
-    CourseEnrollmentError, CourseEnrollmentExistsError, CourseModeNotFoundError,
+    CourseEnrollmentError, CourseEnrollmentExistsError, CourseModeNotFoundError, InvalidEnrollmentAttribute,
 )
 from openedx.core.djangoapps.enrollments.forms import CourseEnrollmentsApiListForm
 from openedx.core.djangoapps.enrollments.paginators import CourseEnrollmentsApiListPagination
@@ -818,6 +818,13 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
 
             log.info('The user [%s] has already been enrolled in course run [%s].', username, course_id)
             return Response(response)
+        except InvalidEnrollmentAttribute as error:
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={
+                    "message": str(error)
+                }
+            )
         except CourseModeNotFoundError as error:
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180.
(link will be updated when that document merges)
-->

## Description

This PR catches EnrollmentNotAllowed and InvalidEnrollmentAttribute exceptions in favor of returning a status 400 bad request. This fixes the 500 error when you make a post request to the /api/enrollment/v1/enrollment.

## How to test
- Have an environment with this version of edx-platform.
- Have the filter configured and a course with the proper "other course settings" as we explained [in the FAN-41 PR](https://github.com/fccn/nau-openedx-extensions/pull/5).
- With a user without an allowed domain, make a post request to /api/enrollment/v1/enrollment with `{"course_details":{"course_id": "<your_course_id>"}}`, and you are going to get an error 400 instead of 500.

### Before
![Screenshot from 2022-12-14 16-59-19](https://user-images.githubusercontent.com/35668326/207726843-d210e7e9-c26f-4fe7-9ab8-e0fb01d83ab1.png)
Response in /api/enrollment/v1/enrollment
![Screenshot from 2022-12-14 16-58-50](https://user-images.githubusercontent.com/35668326/207726876-3f994a23-e9e0-49cd-9186-8d0d80f3d5be.png)
Logs

### After
![Screenshot from 2022-12-14 17-08-31](https://user-images.githubusercontent.com/35668326/207726917-4d44776a-ef5e-4b22-bbf8-cffd8709f780.png)
Response in /api/enrollment/v1/enrollment
![Screenshot from 2022-12-14 17-07-31](https://user-images.githubusercontent.com/35668326/207726957-4bebcfa3-929b-480b-89a7-7988dfb7ed0b.png)
Logs

> Note: If you want to change the message, you need to edit [this](https://github.com/fccn/nau-openedx-extensions/blob/nau/lilac.master/nau_openedx_extensions/filters/pipeline.py#L42) and its translation [here](https://github.com/fccn/nau-openedx-extensions/blob/nau/lilac.master/nau_openedx_extensions/locale/pt_PT/LC_MESSAGES/django.po#L110).