### PR TITLE
feat: add exception message has localizedMessage

### DIFF
--- a/openedx/core/djangoapps/enrollments/views.py
+++ b/openedx/core/djangoapps/enrollments/views.py
@@ -822,7 +822,8 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,
                 data={
-                    "message": str(error)
+                    "message": str(error),
+                    "localizedMessage": str(error),
                 }
             )
         except CourseModeNotFoundError as error:


### PR DESCRIPTION
On Richie integration for the enrollment email domain white list, in case of error raise an error with a `localizedMessage` on the response json.

https://plataforma-nau.atlassian.net/browse/GN-1088

Change to
https://plataforma-nau.atlassian.net/browse/FAN-41
