### PR TITLE
feat: backporting PR#29949

### DIFF
--- a/lms/djangoapps/certificates/management/commands/cert_generation.py
+++ b/lms/djangoapps/certificates/management/commands/cert_generation.py
@@ -10,7 +10,7 @@ from django.core.management.base import BaseCommand, CommandError
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 
-from lms.djangoapps.certificates.generation_handler import generate_certificate_task
+from lms.djangoapps.certificates.generation_handler import generate_certificate_task, CertificateGenerationNotAllowed
 from lms.djangoapps.certificates.models import CertificateGenerationCommandConfiguration
 
 User = get_user_model()
@@ -96,4 +96,11 @@ class Command(BaseCommand):
                         user=user.id,
                         course=course_key
                     ))
-                generate_certificate_task(user, course_key)
+                try:
+                    generate_certificate_task(user, course_key)
+                except CertificateGenerationNotAllowed as e:
+                    log.exception(
+                        "Certificate generation not allowed for user %s in course %s",
+                        user.id,
+                        course_key,
+                    )

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -168,7 +168,7 @@ numpy==1.20.2             # via chem, openedx-calc, scipy
 oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
 openedx-calc==2.0.1       # via -r requirements/edx/base.in
 openedx-events==0.7.1     # via -r requirements/edx/base.in
-openedx-filters==0.4.3    # via -r requirements/edx/base.in
+openedx-filters==0.6.2    # via -r requirements/edx/base.in
 ora2==3.4.1               # via -r requirements/edx/base.in
 packaging==20.9           # via bleach, drf-yasg
 path.py==12.5.0           # via edx-enterprise, edx-i18n-tools, ora2, staff-graded-xblock, xmodule

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -201,7 +201,7 @@ numpy==1.20.2             # via -r requirements/edx/testing.txt, chem, openedx-c
 oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
 openedx-calc==2.0.1       # via -r requirements/edx/testing.txt
 openedx-events==0.7.1     # via -r requirements/edx/testing.txt
-openedx-filters==0.4.3    # via -r requirements/edx/testing.txt
+openedx-filters==0.6.2    # via -r requirements/edx/testing.txt
 ora2==3.4.1               # via -r requirements/edx/testing.txt
 packaging==20.9           # via -r requirements/edx/testing.txt, bleach, drf-yasg, pytest, sphinx, tox
 path.py==12.5.0           # via -r requirements/edx/testing.txt, edx-enterprise, edx-i18n-tools, ora2, staff-graded-xblock, xmodule

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -193,7 +193,7 @@ numpy==1.20.2             # via -r requirements/edx/base.txt, chem, openedx-calc
 oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
 openedx-calc==2.0.1       # via -r requirements/edx/base.txt
 openedx-events==0.7.1     # via -r requirements/edx/base.txt
-openedx-filters==0.4.3    # via -r requirements/edx/base.txt
+openedx-filters==0.6.2    # via -r requirements/edx/base.txt
 ora2==3.4.1               # via -r requirements/edx/base.txt
 packaging==20.9           # via -r requirements/edx/base.txt, bleach, drf-yasg, pytest, tox
 path.py==12.5.0           # via -r requirements/edx/base.txt, edx-enterprise, edx-i18n-tools, ora2, staff-graded-xblock, xmodule


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This PR is a backport of https://github.com/openedx/edx-platform/pull/29949.

However that work was also blocked by

- https://github.com/openedx/edx-platform/pull/28196
- https://github.com/openedx/edx-platform/pull/28102
- https://github.com/openedx/edx-platform/pull/27576


Useful information to include:
- The core of the PR adds the CertificateCreationRequested filter. The differences with the original PR are adaptations to make the code run.

## Supporting information

https://plataforma-nau.atlassian.net/browse/FAN-107

## Testing instructions

Generate a certificate. Nothing should fail.

## Deadline

Before we migrate to Olive. If not then it is no longer necessary. 

## Other information
To be fully functional, this change requires a filter implementation at the nau-plugin. However I'd like to test the assumption that with the imminent migration to ~~olive~~ Nutmeg, backporting this still makes sense. 
