### PR TITLE
feat: add enrollment_date and custom fields to profile data csv backport PR openedx/edx-platform#32216

### DIFF
--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -1141,7 +1141,8 @@ def get_students_features(request, course_id, csv=False):  # pylint: disable=red
             'id', 'username', 'name', 'email', 'language', 'location',
             'year_of_birth', 'gender', 'level_of_education', 'mailing_address',
             'goals', 'enrollment_mode', 'verification_status',
-            'last_login', 'date_joined', 'external_user_key'
+            'last_login', 'date_joined', 'external_user_key',
+            'enrollment_date'
         ]
 
     # Provide human-friendly and translatable names for these features. These names
@@ -1164,6 +1165,7 @@ def get_students_features(request, course_id, csv=False):  # pylint: disable=red
         'last_login': _('Last Login'),
         'date_joined': _('Date Joined'),
         'external_user_key': _('External User Key'),
+        'enrollment_date': _('Enrollment Date'),
     }
 
     if is_course_cohorted(course.id):

--- a/lms/djangoapps/instructor_analytics/basic.py
+++ b/lms/djangoapps/instructor_analytics/basic.py
@@ -10,7 +10,6 @@ import json
 import logging
 
 from django.conf import settings
-from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db.models import Count  # lint-amnesty, pylint: disable=unused-import
@@ -38,6 +37,7 @@ PROFILE_FEATURES = ('name', 'language', 'location', 'year_of_birth', 'gender',
                     'level_of_education', 'mailing_address', 'goals', 'meta',
                     'city', 'country')
 PROGRAM_ENROLLMENT_FEATURES = ('external_user_key', )
+ENROLLMENT_FEATURES = ('enrollment_date', )
 ORDER_ITEM_FEATURES = ('list_price', 'unit_cost', 'status')
 ORDER_FEATURES = ('purchase_time',)
 
@@ -49,7 +49,7 @@ SALE_ORDER_FEATURES = ('id', 'company_name', 'company_contact_name', 'company_co
                        'bill_to_street2', 'bill_to_city', 'bill_to_state', 'bill_to_postalcode',
                        'bill_to_country', 'order_type', 'created')
 
-AVAILABLE_FEATURES = STUDENT_FEATURES + PROFILE_FEATURES + PROGRAM_ENROLLMENT_FEATURES
+AVAILABLE_FEATURES = STUDENT_FEATURES + PROFILE_FEATURES + PROGRAM_ENROLLMENT_FEATURES + ENROLLMENT_FEATURES
 COURSE_REGISTRATION_FEATURES = ('code', 'course_id', 'created_by', 'created_at', 'is_valid')
 COUPON_FEATURES = ('code', 'course_id', 'percentage_discount', 'description', 'expiration_date', 'is_active')
 CERTIFICATE_FEATURES = ('course_id', 'mode', 'status', 'grade', 'created_date', 'is_active', 'error_reason')
@@ -84,7 +84,62 @@ def issued_certificates(course_key, features):
     return generated_certificates
 
 
-def enrolled_students_features(course_key, features):
+def get_student_features_with_custom(course_key):
+    """
+    Allow site operators to include on the export custom fields if platform has an extending
+    User model. This can be used if you have an extended model that include for example
+    an university student number.
+    Basic example of adding age:
+    ```python
+    def get_age(self):
+        return datetime.datetime.now().year - self.profile.year_of_birth
+    setattr(User, 'age', property(get_age))
+    ```
+    Then you have to add `age` to both site configurations:
+    - `student_profile_download_fields_custom_student_attributes`
+    - `student_profile_download_fields` site configurations`
+    ```json
+    "student_profile_download_fields_custom_student_attributes": ["age"],
+    "student_profile_download_fields": [
+        "id", "username", "name", "email", "language", "location",
+        "year_of_birth", "gender", "level_of_education", "mailing_address",
+        "goals", "enrollment_mode", "last_login", "date_joined", "external_user_key",
+        "enrollment_date", "age"
+    ]
+    ```
+    Example if the platform has a custom user extended model like a One-To-One Link
+    with the User Model:
+    ```python
+    def get_user_extended_model_custom_field(self):
+        if hasattr(self, "userextendedmodel"):
+            return self.userextendedmodel.custom_field
+        return None
+    setattr(User, 'user_extended_model_custom_field', property(get_user_extended_model_custom_field))
+    ```
+    ```json
+    "student_profile_download_fields_custom_student_attributes": ["user_extended_model_custom_field"],
+    "student_profile_download_fields": [
+        "id", "username", "name", "email", "language", "location",
+        "year_of_birth", "gender", "level_of_education", "mailing_address",
+        "goals", "enrollment_mode", "last_login", "date_joined", "external_user_key",
+        "enrollment_date", "user_extended_model_custom_field"
+    ]
+    ```
+    """
+    return STUDENT_FEATURES + tuple(
+        configuration_helpers.get_value_for_org(
+            course_key.org,
+            "student_profile_download_fields_custom_student_attributes",
+            getattr(
+                settings,
+                "STUDENT_PROFILE_DOWNLOAD_FIELDS_CUSTOM_STUDENT_ATTRIBUTES",
+                (),
+            ),
+        )
+    )
+
+
+def enrolled_students_features(course_key, features):  # lint-amnesty, pylint: disable=too-many-statements
     """
     Return list of student features as dictionaries.
 
@@ -100,22 +155,24 @@ def enrolled_students_features(course_key, features):
     include_enrollment_mode = 'enrollment_mode' in features
     include_verification_status = 'verification_status' in features
     include_program_enrollments = 'external_user_key' in features
+    include_enrollment_date = 'enrollment_date' in features
     external_user_key_dict = {}
 
-    students = User.objects.filter(
-        courseenrollment__course_id=course_key,
-        courseenrollment__is_active=1,
-    ).order_by('username').select_related('profile')
+    enrollments = CourseEnrollment.objects.filter(
+        course_id=course_key,
+        is_active=1,
+    ).select_related('user').order_by('user__username').select_related('user__profile')
 
     if include_cohort_column:
-        students = students.prefetch_related('course_groups')
+        enrollments = enrollments.prefetch_related('user__course_groups')
 
     if include_team_column:
-        students = students.prefetch_related('teams')
+        enrollments = enrollments.prefetch_related('user__teams')
 
-    # pylint: disable=line-too-long
-    global STUDENT_FEATURES_WITH_CUSTOM
-    STUDENT_FEATURES_WITH_CUSTOM = STUDENT_FEATURES_WITH_CUSTOM + tuple(configuration_helpers.get_value_for_org(course_key.org, 'student_profile_download_fields_custom_student_attributes', getattr(settings, "STUDENT_PROFILE_DOWNLOAD_FIELDS_CUSTOM_STUDENT_ATTRIBUTES", ())))
+    students = [enrollment.user for enrollment in enrollments]
+
+    student_features = [x for x in get_student_features_with_custom(course_key) if x in features]
+    profile_features = [x for x in PROFILE_FEATURES if x in features]
 
     if include_program_enrollments and len(students) > 0:
         program_enrollments = fetch_program_enrollments_by_students(users=students, realized_only=True)
@@ -131,10 +188,9 @@ def enrolled_students_features(course_key, features):
         except TypeError:
             return str(attr)
 
-    def extract_student(student, features):
+    def extract_enrollment_student(enrollment, features):
         """ convert student to dictionary """
-        student_features = [x for x in STUDENT_FEATURES_WITH_CUSTOM if x in features]
-        profile_features = [x for x in PROFILE_FEATURES if x in features]
+        student = enrollment.user
 
         # For data extractions on the 'meta' field
         # the feature name should be in the format of 'meta.foo' where
@@ -185,9 +241,12 @@ def enrolled_students_features(course_key, features):
             # extra external_user_key
             student_dict['external_user_key'] = external_user_key_dict.get(student.id, '')
 
+        if include_enrollment_date:
+            student_dict['enrollment_date'] = enrollment.created
+
         return student_dict
 
-    return [extract_student(student, features) for student in students]
+    return [extract_enrollment_student(enrollment, features) for enrollment in enrollments]
 
 
 def list_may_enroll(course_key, features):

--- a/lms/djangoapps/instructor_analytics/tests/test_basic.py
+++ b/lms/djangoapps/instructor_analytics/tests/test_basic.py
@@ -6,8 +6,11 @@ Tests for instructor.basic
 
 from unittest.mock import MagicMock, Mock, patch
 
+import random
+import datetime
 import ddt
 import json  # lint-amnesty, pylint: disable=wrong-import-order
+from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from edx_proctoring.api import create_exam
 from edx_proctoring.models import ProctoredExamStudentAttempt
 from opaque_keys.edx.locator import UsageKey
@@ -18,6 +21,7 @@ from lms.djangoapps.instructor_analytics.basic import (  # lint-amnesty, pylint:
     PROFILE_FEATURES,
     PROGRAM_ENROLLMENT_FEATURES,
     STUDENT_FEATURES,
+    ENROLLMENT_FEATURES,
     StudentModule,
     enrolled_students_features,
     get_proctored_exam_results,
@@ -27,6 +31,7 @@ from lms.djangoapps.instructor_analytics.basic import (  # lint-amnesty, pylint:
 )
 from lms.djangoapps.program_enrollments.tests.factories import ProgramEnrollmentFactory
 from openedx.core.djangoapps.course_groups.tests.helpers import CohortFactory
+from openedx.core.djangoapps.site_configuration.tests.factories import SiteConfigurationFactory
 from common.djangoapps.student.models import CourseEnrollment, CourseEnrollmentAllowed
 from common.djangoapps.student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
@@ -253,8 +258,61 @@ class TestAnalyticsBasic(ModuleStoreTestCase):
                 assert '' == report['external_user_key']
 
     def test_available_features(self):
-        assert len(AVAILABLE_FEATURES) == len((STUDENT_FEATURES + PROFILE_FEATURES + PROGRAM_ENROLLMENT_FEATURES))
-        assert set(AVAILABLE_FEATURES) == set((STUDENT_FEATURES + PROFILE_FEATURES + PROGRAM_ENROLLMENT_FEATURES))
+        assert len(AVAILABLE_FEATURES) == len(
+            STUDENT_FEATURES +
+            PROFILE_FEATURES +
+            PROGRAM_ENROLLMENT_FEATURES +
+            ENROLLMENT_FEATURES
+        )
+        assert set(AVAILABLE_FEATURES) == set(
+            STUDENT_FEATURES +
+            PROFILE_FEATURES +
+            PROGRAM_ENROLLMENT_FEATURES +
+            ENROLLMENT_FEATURES
+        )
+
+    def test_enrolled_students_enrollment_date(self):
+        query_features = ('username', 'enrollment_date',)
+        for feature in query_features:
+            assert feature in AVAILABLE_FEATURES
+        with self.assertNumQueries(2):
+            userreports = enrolled_students_features(self.course_key, query_features)
+        assert len(userreports) == len(self.users)
+
+        userreports = sorted(userreports, key=lambda u: u["username"])
+        users = sorted(self.users, key=lambda u: u.username)
+        for userreport, user in zip(userreports, users):
+            assert set(userreport.keys()) == set(query_features)
+            assert userreport['enrollment_date'] == CourseEnrollment.enrollments_for_user(user)[0].created
+
+    def test_enrolled_students_extended_model_age(self):
+        SiteConfigurationFactory.create(
+            site_values={
+                'course_org_filter': ['robot'],
+                'student_profile_download_fields_custom_student_attributes': ['age'],
+            }
+        )
+
+        def get_age(self):
+            return datetime.datetime.now().year - self.profile.year_of_birth
+        setattr(User, "age", property(get_age))  # lint-amnesty, pylint: disable=literal-used-as-attribute
+
+        for user in self.users:
+            user.profile.year_of_birth = random.randint(1900, 2000)
+            user.profile.save()
+
+        query_features = ('username', 'age',)
+        with self.assertNumQueries(3):
+            userreports = enrolled_students_features(self.course_key, query_features)
+        assert len(userreports) == len(self.users)
+
+        userreports = sorted(userreports, key=lambda u: u["username"])
+        users = sorted(self.users, key=lambda u: u.username)
+        for userreport, user in zip(userreports, users):
+            assert set(userreport.keys()) == set(query_features)
+            assert userreport['age'] == str(user.age)
+
+        delattr(User, "age")  # lint-amnesty, pylint: disable=literal-used-as-attribute
 
     def test_list_may_enroll(self):
         may_enroll = list_may_enroll(self.course_key, ['email'])


### PR DESCRIPTION
## Description
Back port openedx/edx-platform#32216 to fccn/edx-platform on nau/lilac.master branch.

Add `enrollment_date` column on the csv file of all students enrolled in a course.

Allow site operators to include on the export of profile information as CSV custom fields if the platform has an extending User model. This can be used if you have an extended model that include for example an university student number and site operator want to export the student number on the student profile information CSV.

GN-914


## Supporting information

https://github.com/openedx/edx-platform/pull/32216/

Older prototipo: https://github.com/fccn/edx-platform/pull/5

## Testing instructions

LMS > Course > Instructor > Data download > Download profile information as a CSV

Open a course on the LMS, open the `Instructor` tab, select `Data download` and then click on the button `Download profile information as a CSV`. If you are running on the Devstack the exported file should be on the `/tmp/edx-s3` folder inside the LMS container.

Example:
```bash
make dev.shell.lms
cat /tmp/edx-s3/grades/bb6d638a296059742509a0d319ddf8456b6dbf9a/edX_DemoX_Demo_Course_student_profile_info_2023-05-09-1149.csv
```

## Deadline

ASAP, to make INA partner extract information on self service mode.

## Other information

None