### PR TITLE
fix: generate password with configured validators

### DIFF
--- a/lms/djangoapps/support/views/manage_user.py
+++ b/lms/djangoapps/support/views/manage_user.py
@@ -18,7 +18,7 @@ from lms.djangoapps.support.decorators import require_support_permission
 from openedx.core.djangoapps.user_api.accounts.serializers import AccountUserSerializer
 from openedx.core.djangolib.oauth2_retirement_utils import retire_dot_oauth2_models
 
-from edx_django_utils.user import generate_password  # lint-amnesty, pylint: disable=wrong-import-order
+from openedx.core.djangoapps.user_authn.utils import generate_password  # lint-amnesty, pylint: disable=wrong-import-order
 
 
 class ManageUserSupportView(View):

--- a/openedx/core/djangoapps/user_api/accounts/forms.py
+++ b/openedx/core/djangoapps/user_api/accounts/forms.py
@@ -6,7 +6,7 @@ Django forms for accounts
 from django import forms
 from django.core.exceptions import ValidationError
 
-from edx_django_utils.user import generate_password
+from openedx.core.djangoapps.user_authn.utils import generate_password
 
 
 class RetirementQueueDeletionForm(forms.Form):

--- a/openedx/core/djangoapps/user_api/management/commands/cancel_user_retirement_request.py
+++ b/openedx/core/djangoapps/user_api/management/commands/cancel_user_retirement_request.py
@@ -11,7 +11,7 @@ from django.core.management.base import BaseCommand, CommandError
 
 from openedx.core.djangoapps.user_api.models import UserRetirementStatus
 
-from edx_django_utils.user import generate_password  # lint-amnesty, pylint: disable=wrong-import-order
+from openedx.core.djangoapps.user_authn.utils import generate_password  # lint-amnesty, pylint: disable=wrong-import-order
 
 LOGGER = logging.getLogger(__name__)
 

--- a/openedx/core/djangoapps/user_authn/utils.py
+++ b/openedx/core/djangoapps/user_authn/utils.py
@@ -75,7 +75,7 @@ def password_complexity():
         "common.djangoapps.util.password_policy_validators.MaximumLengthValidator": "max_length",
         "common.djangoapps.util.password_policy_validators.AlphabeticValidator": "min_alphabetic",
         "common.djangoapps.util.password_policy_validators.UppercaseValidator": "min_upper",
-        "common.djangoapps.util.password_policy_validators.LowerValidator": "min_lower",
+        "common.djangoapps.util.password_policy_validators.LowercaseValidator": "min_lower",
         "common.djangoapps.util.password_policy_validators.NumericValidator": "min_numeric",
         "common.djangoapps.util.password_policy_validators.PunctuationValidator": "min_punctuation",
         "common.djangoapps.util.password_policy_validators.SymbolValidator": "min_symbol",

--- a/openedx/core/djangoapps/user_authn/views/auto_auth.py
+++ b/openedx/core/djangoapps/user_authn/views/auto_auth.py
@@ -36,7 +36,7 @@ from common.djangoapps.student.models import (
 )
 from common.djangoapps.util.json_request import JsonResponse
 
-from edx_django_utils.user import generate_password  # lint-amnesty, pylint: disable=wrong-import-order
+from openedx.core.djangoapps.user_authn.utils import generate_password  # lint-amnesty, pylint: disable=wrong-import-order
 
 
 def auto_auth(request):  # pylint: disable=too-many-statements

--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -85,7 +85,7 @@ from common.djangoapps.track import segment
 from common.djangoapps.util.db import outer_atomic
 from common.djangoapps.util.json_request import JsonResponse
 
-from edx_django_utils.user import generate_password  # lint-amnesty, pylint: disable=wrong-import-order
+from openedx.core.djangoapps.user_authn.utils import generate_password  # lint-amnesty, pylint: disable=wrong-import-order
 
 log = logging.getLogger("edx.student")
 AUDIT_LOG = logging.getLogger("audit")


### PR DESCRIPTION
From Lilac to Nutmeg releases the edx-platform `generate_password` function have been moved to the https://github.com/openedx/edx-django-utils repository, so we have lost the use of our custom `generate_password` function.
This is more one of the problems of not sending the custom code also to upstream.

GN-1236