### PR TITLE
feat: add support to extended checkbox field in account settings

### DIFF
--- a/lms/static/js/student_account/views/account_settings_factory.js
+++ b/lms/static/js/student_account/views/account_settings_factory.js
@@ -299,14 +299,24 @@
                             persistChanges: true
                         })
                     });
+                } else if (fieldItem.field_type === 'ListField') {
+                    additionalFields.fields.push({
+                        view: new AccountSettingsFieldViews.ExtendedFieldListFieldView({
+                            model: userAccountModel,
+                            title: fieldItem.field_label,
+                            fieldName: fieldItem.field_name,
+                            options: fieldItem.field_options,
+                            valueAttribute: 'extended_profile',
+                            persistChanges: true
+                        })
+                    });
                 } else {
-                    if (fieldItem.field_type === 'ListField') {
+                    if (fieldItem.field_type === 'CheckboxField') {
                         additionalFields.fields.push({
-                            view: new AccountSettingsFieldViews.ExtendedFieldListFieldView({
+                            view: new AccountSettingsFieldViews.ExtendedFieldCheckboxFieldView({
                                 model: userAccountModel,
                                 title: fieldItem.field_label,
                                 fieldName: fieldItem.field_name,
-                                options: fieldItem.field_options,
                                 valueAttribute: 'extended_profile',
                                 persistChanges: true
                             })

--- a/lms/static/js/student_account/views/account_settings_fields.js
+++ b/lms/static/js/student_account/views/account_settings_fields.js
@@ -8,6 +8,7 @@
         'underscore',
         'backbone',
         'js/views/fields',
+        'text!templates/fields/field_checkbox_account.underscore',
         'text!templates/fields/field_text_account.underscore',
         'text!templates/fields/field_readonly_account.underscore',
         'text!templates/fields/field_link_account.underscore',
@@ -19,6 +20,7 @@
     ], function(
         gettext, $, _, Backbone,
         FieldViews,
+        field_checkbox_account_template,
         field_text_account_template,
         field_readonly_account_template,
         field_link_account_template,
@@ -282,7 +284,7 @@
             ExtendedFieldTextFieldView: FieldViews.TextFieldView.extend({
                 render: function() {
                     HtmlUtils.setHtml(this.$el, HtmlUtils.template(field_text_account_template)({
-                        id: this.options.valueAttribute + '_' + this.options.field_name,
+                        id: this.options.valueAttribute + '_' + this.options.fieldName,
                         title: this.options.title,
                         value: this.modelValue(),
                         message: this.options.helpMessage,
@@ -337,6 +339,64 @@
                         this.saveAttributes(attributes);
                     }
                 }
+            }),
+            ExtendedFieldCheckboxFieldView: FieldViews.EditableFieldView.extend({
+
+                fieldType: 'checkbox',
+                fieldTemplate: field_checkbox_account_template,
+
+                events: {
+					'change input': 'saveValue'
+				},
+
+				initialize: function(options) {
+					this._super(options);
+					_.bindAll(this, 'render', 'fieldValue', 'updateValueInField', 'saveValue');
+					this.listenTo(this.model, 'change:' + this.options.valueAttribute, this.updateValueInField);
+				},
+
+				render: function () {
+					HtmlUtils.setHtml(this.$el, HtmlUtils.template(field_checkbox_account_template)({
+						id: this.options.valueAttribute + '_' + this.options.fieldName,
+						title: this.options.title,
+						value: this.modelValue(),
+						message: this.options.helpMessage
+					}));
+					this.delegateEvents();
+					return this;
+				},
+
+				modelValue: function () {
+					var extendedProfileFields = this.model.get(this.options.valueAttribute);
+					for (var i = 0; i < extendedProfileFields.length; i++) { // eslint-disable-line vars-on-top
+						if (extendedProfileFields[i].field_name === this.options.fieldName) {
+							return extendedProfileFields[i].field_value;
+						}
+					}
+					return null;
+				},
+
+				fieldValue: function() {
+					return this.$('.u-field-value input').is(':checked');
+				},
+
+				updateValueInField: function() {
+					const checked = this.modelValue() === true;
+					this.$('.u-field-value input').prop('checked', checked);
+				},
+
+				saveValue: function () {
+					let attributes = {}, value;
+
+					if (this.persistChanges === true) {
+						value = [{
+							field_name: this.options.fieldName,
+							field_value: !!this.fieldValue()
+						}];
+						attributes[this.options.valueAttribute] = value;
+						this.saveAttributes(attributes);
+					}
+				}
             }),
             AuthFieldView: FieldViews.LinkFieldView.extend({
                 fieldTemplate: field_social_link_template,

--- a/lms/static/js/student_account/views/account_settings_fields.js
+++ b/lms/static/js/student_account/views/account_settings_fields.js
@@ -346,57 +346,57 @@
                 fieldTemplate: field_checkbox_account_template,
 
                 events: {
-					'change input': 'saveValue'
-				},
+                    'change input': 'saveValue'
+                },
 
-				initialize: function(options) {
-					this._super(options);
-					_.bindAll(this, 'render', 'fieldValue', 'updateValueInField', 'saveValue');
-					this.listenTo(this.model, 'change:' + this.options.valueAttribute, this.updateValueInField);
-				},
+                initialize: function(options) {
+                    this._super(options);
+                    _.bindAll(this, 'render', 'fieldValue', 'updateValueInField', 'saveValue');
+                    this.listenTo(this.model, 'change:' + this.options.valueAttribute, this.updateValueInField);
+                },
 
-				render: function () {
-					HtmlUtils.setHtml(this.$el, HtmlUtils.template(field_checkbox_account_template)({
-						id: this.options.valueAttribute + '_' + this.options.fieldName,
-						title: this.options.title,
-						value: this.modelValue(),
-						message: this.options.helpMessage
-					}));
-					this.delegateEvents();
-					return this;
-				},
+                render: function () {
+                    HtmlUtils.setHtml(this.$el, HtmlUtils.template(field_checkbox_account_template)({
+                        id: this.options.valueAttribute + '_' + this.options.fieldName,
+                        title: this.options.title,
+                        value: this.modelValue(),
+                        message: this.options.helpMessage
+                    }));
+                    this.delegateEvents();
+                    return this;
+                },
 
-				modelValue: function () {
-					var extendedProfileFields = this.model.get(this.options.valueAttribute);
-					for (var i = 0; i < extendedProfileFields.length; i++) { // eslint-disable-line vars-on-top
-						if (extendedProfileFields[i].field_name === this.options.fieldName) {
-							return extendedProfileFields[i].field_value;
-						}
-					}
-					return null;
-				},
+                modelValue: function () {
+                    var extendedProfileFields = this.model.get(this.options.valueAttribute);
+                    for (var i = 0; i < extendedProfileFields.length; i++) { // eslint-disable-line vars-on-top
+                        if (extendedProfileFields[i].field_name === this.options.fieldName) {
+                            return extendedProfileFields[i].field_value;
+                        }
+                    }
+                    return null;
+                },
 
-				fieldValue: function() {
-					return this.$('.u-field-value input').is(':checked');
-				},
+                fieldValue: function() {
+                    return this.$('.u-field-value input').is(':checked');
+                },
 
-				updateValueInField: function() {
-					const checked = this.modelValue() === true;
-					this.$('.u-field-value input').prop('checked', checked);
-				},
+                updateValueInField: function() {
+                    const checked = this.modelValue() === true;
+                    this.$('.u-field-value input').prop('checked', checked);
+                },
 
-				saveValue: function () {
-					let attributes = {}, value;
+                saveValue: function () {
+                    let attributes = {}, value;
 
-					if (this.persistChanges === true) {
-						value = [{
-							field_name: this.options.fieldName,
-							field_value: !!this.fieldValue()
-						}];
-						attributes[this.options.valueAttribute] = value;
-						this.saveAttributes(attributes);
-					}
-				}
+                    if (this.persistChanges === true) {
+                        value = [{
+                            field_name: this.options.fieldName,
+                            field_value: !!this.fieldValue()
+                        }];
+                        attributes[this.options.valueAttribute] = value;
+                        this.saveAttributes(attributes);
+                    }
+                }
             }),
             AuthFieldView: FieldViews.LinkFieldView.extend({
                 fieldTemplate: field_social_link_template,

--- a/lms/templates/fields/field_checkbox_account.underscore
+++ b/lms/templates/fields/field_checkbox_account.underscore
@@ -1,6 +1,6 @@
-<div class="u-field-value field">
-    <label class="u-field-title field-label" for="field-input-<%- id %>"><%- title %></label>
-    <input class="field-input input-checkbox" type="checkbox"
+<div class="u-field-value field" style="display: flex;flex-direction: row-reverse;align-items: center;justify-content: flex-end;gap:1em;">
+    <label class="u-field-title field-label" for="field-input-<%- id %>" style="margin:0;"><%= title %></label>
+    <input class="field-input input-checkbox" type="checkbox" style="min-width:25px;"
            id="field-input-<%- id %>"
            title="Checkbox field for <%- id %>"
            aria-describedby="u-field-message-help-<%- id %>"

--- a/lms/templates/fields/field_checkbox_account.underscore
+++ b/lms/templates/fields/field_checkbox_account.underscore
@@ -1,0 +1,13 @@
+<div class="u-field-value field">
+    <label class="u-field-title field-label" for="field-input-<%- id %>"><%- title %></label>
+    <input class="field-input input-checkbox" type="checkbox"
+           id="field-input-<%- id %>"
+           title="Checkbox field for <%- id %>"
+           aria-describedby="u-field-message-help-<%- id %>"
+           name="input"
+           <% if (value) { %>checked<% } %> />
+</div>
+<span class="u-field-message" id="u-field-message-<%- id %>">
+    <span class="u-field-message-notification" aria-live="polite"></span>
+    <span class="u-field-message-help" id="u-field-message-help-<%- id %>"><%= HtmlUtils.ensureHtml(message) %></span>
+</span>


### PR DESCRIPTION
## Description
This PR adds support to Extended CheckBox Fields in the Account Settings.  

## Supporting information
- https://github.com/fccn/nau-technical/issues/279
- https://github.com/eduNEXT/consulting-issues-mapping/issues/10

## Testing instructions

1. Create a Tutor environment in the Redwood version.
2. Install `nau-openedx-extensions` plugin with the changes in [this PR](https://github.com/fccn/nau-openedx-extensions/pull/57).
3. Create a mount of `edx-platform` with the changes in this PR.
4. Update the `account.redirect_to_microfrontend` Waffle Flag. Set `Everyone` to `No`. This allows access to the legacy interface.
5. Go to `{lms_domain}/account/settings`
6. You should see the new checkbox field in the **Additional Information** section.
7. Try to update the field and verify that the value was updated in the model.

### Screenshots
![image](https://github.com/user-attachments/assets/18f1baaf-f2fc-4e6e-b7ea-c097d8976cba)