### PR TITLE
DRAFT: added GAMMA_SETTINGS_URL env variable

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -829,6 +829,8 @@ LMS_BASE = 'localhost:18000'
 LMS_ROOT_URL = "https://localhost:18000"
 LMS_INTERNAL_ROOT_URL = LMS_ROOT_URL
 
+GAMMA_SETTINGS_URL = "http://0.0.0.0:9700/gamma/badges/"
+
 # Use LMS SSO for login, once enabled by setting LOGIN_URL (see docs/guides/studio_oauth.rst)
 SOCIAL_AUTH_STRATEGY = 'auth_backends.strategies.EdxDjangoStrategy'
 LOGIN_REDIRECT_URL = EDX_ROOT_URL + '/home/'


### PR DESCRIPTION
## Description

Added `GAMMA_SETTINGS_URL` env variable for Gamification settings.

## Testing instructions

1. Enable `ENABLE_RG_GAMIFICATION` feature flag.
2. Configure `GAMMA_SETTINGS_URL`.
3. Open legacy LMS/CMS page.
4. Ensure the Leaderboard, Dashboard, Gamma Settings links are displayed in the user dropdown menu in the header.

![image](https://github.com/user-attachments/assets/21cc423c-1467-4de1-b7bc-74b8fd5d6121)

![image](https://github.com/user-attachments/assets/4645672e-6a51-4590-99e3-e4ce14e94b34)

## Relative PRs

- [frontend-component-header-nau](https://github.com/fccn/frontend-component-header-nau)
- [nau-themes](https://github.com/fccn/nau-themes/pull/70)

