### PR TITLE
feat: add feature toggle for private fields in profile information report

### DIFF
--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -22,6 +22,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.http import HttpRequest, HttpResponse
 from django.test import RequestFactory, TestCase
 from django.test.client import MULTIPART_CONTENT
+from django.test.utils import override_settings
 from django.urls import reverse as django_reverse
 from django.utils.translation import gettext as _
 from edx_when.api import get_dates_for_course, get_overrides_for_user, set_date_for_block
@@ -2591,6 +2592,23 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
             assert student_json['email'] == student.email
             assert student_json['city'] == student.profile.city
             assert student_json['country'] == ''
+
+    @ddt.data(True, False)
+    def test_get_students_features_private_fields(self, show_private_fields):
+        """
+        Test that the get_students_features returns the expected private fields
+        """
+        with override_settings(FEATURES={'SHOW_PRIVATE_FIELDS_IN_PROFILE_INFORMATION_REPORT': show_private_fields}):
+            url = reverse('get_students_features', kwargs={'course_id': str(self.course.id)})
+            response = self.client.post(url, {})
+            res_json = json.loads(response.content.decode('utf-8'))
+
+            assert 'students' in res_json
+            for student in res_json['students']:
+                if show_private_fields:
+                    assert 'year_of_birth' in student
+                else:
+                    assert 'year_of_birth' not in student
 
     @ddt.data(True, False)
     def test_get_students_features_cohorted(self, is_cohorted):

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -1436,7 +1436,6 @@ def get_students_features(request, course_id, csv=False):  # pylint: disable=red
             'last_login', 'date_joined', 'external_user_key',
             'enrollment_date'
         ]
-    # keep_field_private(query_features, 'year_of_birth')  # protected information
 
     # Provide human-friendly and translatable names for these features. These names
     # will be displayed in the table generated in data_download.js. It is not (yet)
@@ -1448,7 +1447,7 @@ def get_students_features(request, course_id, csv=False):  # pylint: disable=red
         'email': _('Email'),
         'language': _('Language'),
         'location': _('Location'),
-        'year_of_birth': _('Birth Year'),  # treated as privileged information as of TNL-10683, not to go in reports
+        'year_of_birth': _('Birth Year'),
         'gender': _('Gender'),
         'level_of_education': _('Level of Education'),
         'mailing_address': _('Mailing Address'),
@@ -1459,6 +1458,10 @@ def get_students_features(request, course_id, csv=False):  # pylint: disable=red
         'external_user_key': _('External User Key'),
         'enrollment_date': _('Enrollment Date'),
     }
+
+    if not settings.FEATURES.get('SHOW_PRIVATE_FIELDS_IN_PROFILE_INFORMATION_REPORT', False):
+            keep_field_private(query_features, 'year_of_birth')
+            query_features_names.pop('year_of_birth', None)
 
     if is_course_cohorted(course.id):
         # Translators: 'Cohort' refers to a group of students within a course.

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1085,6 +1085,16 @@ FEATURES = {
     # .. toggle_creation_date: 2024-04-02
     # .. toggle_target_removal_date: None
     'BADGES_ENABLED': False,
+
+    # .. toggle_name: FEATURES['SHOW_PRIVATE_FIELDS_IN_PROFILE_INFORMATION_REPORT']
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Adds private fields to the profile information report.
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2025-05-12
+    # .. toggle_target_removal_date: None
+    # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/36688
+    'SHOW_PRIVATE_FIELDS_IN_PROFILE_INFORMATION_REPORT': False,
 }
 
 # Specifies extra XBlock fields that should available when requested via the Course Blocks API


### PR DESCRIPTION
## Description

This PR introduces a new feature toggle called `SHOW_PRIVATE_FIELDS_IN_PROFILE_INFORMATION_REPORT`. This toggle allows operators to include private fields (such as `year_of_birth`) in the profile information JSON report or CSV file.

### Context

A PR in upstream was created (https://github.com/openedx/edx-platform/pull/36688). For the time being, the changes will be applied directly in this fork until the upstream merge is performed.

## Testing instructions

1. Create a Tutor environment.
2. Create a mount of **edx-platform** with the changes in this PR.
3. Create a course and enroll some students in it.
4. Then, go to the **LMS > [Your Course] > Instructor > Data Download > Download profile information as a CSV**.
5. You shouldn't see the `year_of_birth` column in the CSV.
6. Now, enable the new feature toggle in your settings. You can use this tutor inline plugin

    ```yaml
    name: common-settings
    version: 1.0.0
    patches:
      openedx-common-settings: |
        FEATURES['SHOW_PRIVATE_FIELDS_IN_PROFILE_INFORMATION_REPORT'] = True
    ```

7. Again, download profile information as a CSV.
8. You should see the `year_of_birth` column in the CSV.

## Screenshots

### With the Flag Deactivated _(Default)_

![image](https://github.com/user-attachments/assets/9c32bc45-5cd7-40e7-9d1e-4b739b34cd8a)

### With the Flag Activated

![image](https://github.com/user-attachments/assets/992570d1-25c5-451d-9d79-361337083d5c)

## Other information

- [Discuss Thread](https://discuss.openedx.org/t/how-to-add-column-year-of-birth-to-export-download-a-csv-of-learners-who-can-enroll/14973/1
)
