### PR TITLE
Revert commit "fix: remove cache condition in production" due is not longer useful 

### DIFF
--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -201,6 +201,8 @@ if 'loc_cache' not in CACHES:
         'LOCATION': 'edx_location_mem_cache',
     }
 
+if 'staticfiles' in CACHES:
+    CACHES['staticfiles']['KEY_PREFIX'] = EDX_PLATFORM_REVISION
 
 # In order to transition from local disk asset storage to S3 backed asset storage,
 # we need to run asset collection twice, once for local disk and once for S3.

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -218,6 +218,8 @@ if 'loc_cache' not in CACHES:
         'LOCATION': 'edx_location_mem_cache',
     }
 
+if 'staticfiles' in CACHES:
+    CACHES['staticfiles']['KEY_PREFIX'] = EDX_PLATFORM_REVISION
 
 # In order to transition from local disk asset storage to S3 backed asset storage,
 # we need to run asset collection twice, once for local disk and once for S3.


### PR DESCRIPTION
**This reverts commit [11af82ca12b8a68e359d57ed91cbda447461c52c](https://github.com/fccn/edx-platform/commit/11af82ca12b8a68e359d57ed91cbda447461c52c).**


## Description

After the investigation, it can be concluded that this commit is not necessary, since Tutor is going to overwrite it.

I performed the following tests by adding the if-block, and indeed the behavior does not change. Even when testing with an upstream environment different from the one used by NAU, the behavior remains the same, and the value of EDX_PLATFORM_REVISION continues to be staticfiles_lms or staticfiles_cms, respectively.

This revert prevents future work to be done.


## How to test 

- Open your lms shell by running:
`python manage.py lms shell` or `python manage.py cms shell`
- Run the following lines to check the KEY_PREFIX settled
`from django.conf import settings`
 `print(settings.CACHES['staticfiles'].get('KEY_PREFIX'))`

- Output 
`staticfiles_lms` or `staticfiles_cms`

## Note:
I will leave a note in the [excel](https://docs.google.com/spreadsheets/d/1GCQ5W8rbi1jBshaYeNnl5pvX8ktL9mb5zxw11i7n5jg/edit?pli=1&gid=0#gid=0) file explaining why the commit is not longer needed and doesn`t need to be cherry-picked 

## Reated issue:
https://github.com/fccn/nau-technical/issues/394