### PR TITLE
fix: commerce and enrollment error handling and ux (#36612)

### DIFF
--- a/lms/djangoapps/commerce/api/v0/views.py
+++ b/lms/djangoapps/commerce/api/v0/views.py
@@ -10,17 +10,18 @@ from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from requests.exceptions import HTTPError
 from rest_framework.permissions import IsAuthenticated
-from rest_framework.status import HTTP_406_NOT_ACCEPTABLE, HTTP_409_CONFLICT
+from rest_framework.status import HTTP_406_NOT_ACCEPTABLE, HTTP_409_CONFLICT, HTTP_400_BAD_REQUEST, HTTP_403_FORBIDDEN
 from rest_framework.views import APIView
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.entitlements.models import CourseEntitlement
-from common.djangoapps.student.models import CourseEnrollment
+from common.djangoapps.student.models import CourseEnrollment, EnrollmentNotAllowed
 from common.djangoapps.util.json_request import JsonResponse
 from lms.djangoapps.courseware import courses
 from openedx.core.djangoapps.commerce.utils import get_ecommerce_api_base_url, get_ecommerce_api_client
 from openedx.core.djangoapps.embargo import api as embargo_api
 from openedx.core.djangoapps.enrollments.api import add_enrollment
+from openedx.core.djangoapps.enrollments.errors import InvalidEnrollmentAttribute
 from openedx.core.djangoapps.enrollments.views import EnrollmentCrossDomainSessionAuth
 from openedx.core.djangoapps.user_api.preferences.api import update_email_opt_in
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
@@ -149,13 +150,52 @@ class BasketsView(APIView):
                     announcement=course_announcement
                 )
             log.info(msg)
-            self._enroll(course_key, user, default_enrollment_mode.slug)
+
+            try:
+                self._enroll(course_key, user, default_enrollment_mode.slug)
+            except InvalidEnrollmentAttribute as e:
+                # Exception handling for InvalidEnrollmentAttribute
+                return self._handle_enrollment_error(
+                    e,
+                    user,
+                    course_id,
+                    "Invalid enrollment attribute ",
+                    HTTP_400_BAD_REQUEST
+                )
+            except EnrollmentNotAllowed as e:
+                # Exception handling for EnrollmentNotAllowed
+                return self._handle_enrollment_error(
+                    e,
+                    user,
+                    course_id,
+                    "Enrollment not allowed ",
+                    HTTP_403_FORBIDDEN
+                )
+
             mode = CourseMode.AUDIT if audit_mode else CourseMode.HONOR  # lint-amnesty, pylint: disable=unused-variable
             self._handle_marketing_opt_in(request, course_key, user)
             return DetailResponse(msg)
         else:
             msg = Messages.NO_DEFAULT_ENROLLMENT_MODE.format(course_id=course_id)
             return DetailResponse(msg, status=HTTP_406_NOT_ACCEPTABLE)
+
+    def _handle_enrollment_error(self, exception, user, course_id, log_message, status_code):
+        """
+        Helper function to handle enrollment exceptions.
+
+        Args:
+            exception (Exception): The exception raised.
+            user (User): The user attempting to enroll.
+            course_id (str): The course ID.
+            log_message (str): The log message template.
+            status_code (int): The HTTP status code to return.
+
+        Returns:
+            DetailResponse: The response with the error message and status code.
+        """
+        log.exception(log_message, str(exception))
+        error_msg = f"{log_message.format(str(exception))} for user {user.username} in course {course_id}: {str(exception)}"  # lint-amnesty, pylint: disable=line-too-long
+        return DetailResponse(error_msg, status=status_code)
 
 
 class BasketOrderView(APIView):

--- a/lms/static/js/student_account/enrollment.js
+++ b/lms/static/js/student_account/enrollment.js
@@ -2,6 +2,11 @@
     'use strict';
 
     define(['jquery', 'jquery.cookie'], function($) {
+        const ErrorStatuses = {
+            forbidden: 403,
+            badRequest: 400
+        };
+
         var EnrollmentInterface = {
 
             urls: {
@@ -30,12 +35,14 @@
                     context: this
                 }).fail(function(jqXHR) {
                     var responseData = JSON.parse(jqXHR.responseText);
-                    if (jqXHR.status === 403 && responseData.user_message_url) {
-                        // Check if we've been blocked from the course
-                        // because of country access rules.
-                        // If so, redirect to a page explaining to the user
-                        // why they were blocked.
-                        this.redirect(responseData.user_message_url);
+                    if (jqXHR.status === ErrorStatuses.forbidden) {
+                        if (responseData.user_message_url) {
+                            this.redirect(responseData.user_message_url);
+                        } else {
+                            this.showMessage(responseData);
+                        }
+                    } else if (jqXHR.status === ErrorStatuses.badRequest) {
+                        this.showMessage(responseData);
                     } else {
                         // Otherwise, redirect the user to the next page.
                         if (redirectUrl) {
@@ -52,7 +59,54 @@
                     }
                 });
             },
+            /**
+             * Show a message in the frontend.
+             * @param  {Object} message The message to display.
+             */
+            showMessage: function(message) {
+                const componentId = 'student-enrollment-feedback-error';
+                const existing = document.getElementById(componentId);
+                if (existing) {
+                    existing.remove();
+                }
+                // Using a fixed dashboard URL as the redirect destination since this is the most logical
+                // place for users to go after encountering an enrollment error. The URL is hardcoded
+                // because environment variables are not injected into the HTML/JavaScript context.
+                const DASHBOARD_URL = '/dashboard';
+                const textContent = (message && message.detail) ? message.detail : String(message);
+                const messageDiv = document.createElement('div');
+                messageDiv.setAttribute('id', componentId);
+                messageDiv.setAttribute('class', 'fixed-top d-flex justify-content-center align-items-center');
+                messageDiv.style.cssText = [
+                    'width:100vw',
+                    'height:100vh',
+                    'background:rgba(0,0,0,0.5)',
+                    'z-index:9999'
+                ].join(';');
 
+                const buttonText = typeof gettext === 'function' ? gettext('Close') : 'Close';
+
+                messageDiv.innerHTML = `
+                  <div class="page-banner w-75 has-actions">
+                    <div class="alert alert-warning" role="alert">
+                      <div class="row w-100">
+                        <div class="col d-flex align-items-center">
+                          <span class="icon icon-alert fa fa-warning me-2" aria-hidden="true"></span>
+                          <span class="message-content" style="min-width: 0; overflow-wrap: anywhere;">${textContent}</span>
+                        </div>
+                         <div class="nav-actions mt-3 flex-row-reverse d-none">
+                          <button type="button" class="action-primary" id="enrollment-redirect-btn">${buttonText}</button>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                `;
+                const actionContainer = messageDiv.querySelector('.nav-actions');
+                actionContainer.classList.replace('d-none', 'd-flex');
+                actionContainer.querySelector('button').addEventListener('click', () => this.redirect(DASHBOARD_URL) )
+                document.body.appendChild(messageDiv);
+
+            },
             /**
              * Redirect to a URL.  Mainly useful for mocking out in tests.
              * @param  {string} url The URL to redirect to.
@@ -65,3 +119,4 @@
         return EnrollmentInterface;
     });
 }).call(this, define || RequireJS.define);
+

--- a/openedx/core/djangoapps/enrollments/views.py
+++ b/openedx/core/djangoapps/enrollments/views.py
@@ -27,7 +27,7 @@ from rest_framework.views import APIView  # lint-amnesty, pylint: disable=wrong-
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.auth import user_has_role
-from common.djangoapps.student.models import CourseEnrollment, CourseEnrollmentAllowed, User
+from common.djangoapps.student.models import CourseEnrollment, CourseEnrollmentAllowed, EnrollmentNotAllowed, User
 from common.djangoapps.student.roles import CourseStaffRole, GlobalStaff
 from common.djangoapps.util.disable_rate_limit import can_disable_rate_limit
 from openedx.core.djangoapps.cors_csrf.authentication import SessionAuthenticationCrossDomainCsrf
@@ -36,7 +36,10 @@ from openedx.core.djangoapps.course_groups.cohorts import CourseUserGroup, add_u
 from openedx.core.djangoapps.embargo import api as embargo_api
 from openedx.core.djangoapps.enrollments import api
 from openedx.core.djangoapps.enrollments.errors import (
-    CourseEnrollmentError, CourseEnrollmentExistsError, CourseModeNotFoundError, InvalidEnrollmentAttribute,
+    CourseEnrollmentError,
+    CourseEnrollmentExistsError,
+    CourseModeNotFoundError,
+    InvalidEnrollmentAttribute,
 )
 from openedx.core.djangoapps.enrollments.forms import CourseEnrollmentsApiListForm
 from openedx.core.djangoapps.enrollments.paginators import CourseEnrollmentsApiListPagination
@@ -868,6 +871,14 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
                     "localizedMessage": str(error),
                 }
             )
+        except EnrollmentNotAllowed as error:
+            return Response(
+                status=status.HTTP_403_FORBIDDEN,
+                data={
+                    "message": str(error),
+                    "localizedMessage": str(error),
+                }
+            )
         except CourseModeNotFoundError as error:
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,
@@ -899,6 +910,7 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
                     ).format(username=username, course_id=course_id)
                 }
             )
+
         except CourseUserGroup.DoesNotExist:
             log.exception('Missing cohort [%s] in course run [%s]', cohort_name, course_id)
             return Response(


### PR DESCRIPTION
Backport from: https://github.com/openedx/edx-platform/pull/36612

### Summary

This PR improves both backend and frontend handling of enrollment errors, ensuring users receive clear feedback and the system returns appropriate HTTP responses when enrollment is not allowed.

---

### Objective

- Return HTTP 400 (Bad request) instead of HTTP 500 when enrollment is not allowed.
- Prevent infinite loading spinners on the enrollment page.
- Display clear error messages to users before redirecting them.
- Ensure consistent and meaningful responses from enrollment-related API endpoints.

---

### Technical Details

#### Backend (`views.py` in enrollments and commerce/api/v0)

- **Exception Handling:**  
  - Updated logic to catch  `InvalidEnrollmentAttribute`.
  - API now returns HTTP 400 with a descriptive error message instead of HTTP 500.
- **API Consistency:**  
  - Both `/api/enrollment/v1/enrollment` and `/api/commerce/v0/baskets/` endpoints now provide coherent and user-friendly error responses.

#### Frontend (`enrollment.js`)

- **Spinner Fix:**  
  - Fixed the issue where the spinner would remain indefinitely if enrollment failed.
- **User Feedback:**  
  - When enrollment is not allowed, the error message is shown in a pop-up before redirecting the user to the learner dashboard when user clicks on the "close" button.
  - Users are now informed of the specific reason for the failure.

---

## Test cases and instructions:

- To replicate the issue I used this filter org.openedx.learning.course.enrollment.started.v1 with a custom pipeline to restrict the enrollment by domain.
- The pipeline has this:
```
def run_filter(self, user, course_key, mode):   # pylint: disable=unused-argument, arguments-differ
        """Filter."""

        other_course_settings = get_other_course_settings(course_key)
        domains_allowed = (
            other_course_settings.get("value", {}).get("filter_enrollment_by_domain_list") or
            other_course_settings.get("value", {}).get("filterEnrollmentByDomainList")
        )

        if domains_allowed:
            if not user.is_active:
                platform_name = configuration_helpers.get_value("platform_name", settings.PLATFORM_NAME)
                exception_msg = _(
                    "You need to activate your account before you can enroll in the course. "
                    "Check your {email} inbox for an account activation link from {platform_name}."
                ).format(email=user.email, platform_name=platform_name)
                raise CourseEnrollmentStarted.PreventEnrollment(exception_msg)

            cea = get_student_course_enrollment_allowed(user, course_key)
            # if the student is allowed to enroll, skip checking the email domain
            # validate the email domain if user is not already enrolled
            if not cea and not get_enrollment(user, course_key):
                if not FilterEnrollmentByDomain._is_user_email_allowed(user, domains_allowed):
                    custom_message = other_course_settings.get("value", {}).get(
                        "filter_enrollment_by_domain_custom_exception_message",
                        _("If you think this is an error, contact the course support."))
                    exception_msg = _("You can't enroll on this course because your email domain is not allowed. "
                                      "%(custom_message)s") % {
                        'custom_message': custom_message}
                    raise CourseEnrollmentStarted.PreventEnrollment(exception_msg)

        return {}

    @staticmethod
    def _is_user_email_allowed(user, domains_allowed):
        """
        Check if the user email is a domain or sub-domain of the allowed domains.
        """
        user_domain = user.email.split("@")[1].lower()
        for domain in domains_allowed:
            if user_domain == domain or fnmatch(user_domain, f"*.{domain}"):
                return True
        return False
```

- Also yo need to allow the other_course_settings with:
```
hooks.Filters.ENV_PATCHES.add_item(
    (
        "openedx-common-settings",
"""
FEATURES["ENABLE_OTHER_COURSE_SETTINGS"] = True
"""
    )
)
```

- And set the allowed domains in the course advanced_settings such as:

![image](https://github.com/user-attachments/assets/d4a30a38-0946-4e3f-9596-7affad03d998)

- And use an user who doesn't have an allowed email

1. The 500 error occurred when making a POST request to these endpoints when enrollment is not allowed: `/api/enrollment/v1/enrollment` and `/api/commerce/v0/baskets/  `, now it drops 400 error instead

2. When using: `http://apps.local.edly.io:1999/authn/login?course_id=<course_name>&enrollment_action=enroll`, an spinner and a message are rendered when attempting to enroll when it is not allowed, once the user click the button "close" it will be redirected to the learner dashboard.







https://github.com/user-attachments/assets/ce695e92-f0c5-44dd-b352-2324d4eabdc6











### Impact

- Users receive immediate and clear feedback when enrollment is not possible.
- The frontend no longer hangs on failed enrollments.
- API responses are more accurate and easier to debug.

---


