### PR TITLE
revert: remove features no longer needed 

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -121,11 +121,6 @@ from lms.envs.common import (
     # Methods to derive settings
     _make_mako_template_dirs,
     _make_locale_paths,
-
-    # Password Validator Settings
-    AUTH_PASSWORD_VALIDATORS,
-    _make_locale_paths_prepend,
-
 )
 from path import Path as path
 from django.urls import reverse_lazy
@@ -1316,7 +1311,7 @@ USE_L10N = True
 STATICI18N_FILENAME_FUNCTION = 'statici18n.utils.legacy_filename'
 STATICI18N_ROOT = PROJECT_ROOT / "static"
 
-LOCALE_PATHS = _make_locale_paths_prepend
+LOCALE_PATHS = _make_locale_paths
 derived('LOCALE_PATHS')
 
 # Messages

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -121,6 +121,10 @@ from lms.envs.common import (
     # Methods to derive settings
     _make_mako_template_dirs,
     _make_locale_paths,
+
+    # Password Validator Settings
+    AUTH_PASSWORD_VALIDATORS,
+
 )
 from path import Path as path
 from django.urls import reverse_lazy

--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -18,7 +18,6 @@ from openedx.core.djangolib.js_utils import (
 )
 from openedx.core.djangolib.markup import HTML
 from openedx.core.release import RELEASE_LINE
-from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 %>
 
 <%page expression_filter="h"/>
@@ -68,12 +67,6 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
     % endif
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="path_prefix" content="${EDX_ROOT_URL}">
-    <%block name="header_meta"></%block>
-    <% educast_site_id = configuration_helpers.get_value('EDUCAST_SITE_ID', '')%>
-    % if user.is_authenticated and educast_site_id:
-    <meta name="integration" content="${educast_site_id}">
-    % endif
-
     <% favicon_url = branding_api.get_favicon_url() %>
     <link rel="icon" type="image/x-icon" href="${favicon_url}"/>
     <%static:css group='style-vendor'/>

--- a/common/djangoapps/util/cache.py
+++ b/common/djangoapps/util/cache.py
@@ -10,7 +10,6 @@ not migrating so as not to inconvenience users by logging them all out.
 from functools import wraps
 from urllib.parse import urlencode
 
-from django.conf import settings
 from django.core import cache
 # If we can't find a 'general' CACHE defined in settings.py, we simply fall back
 # to returning the default cache. This will happen with dev machines.
@@ -55,8 +54,7 @@ def cache_if_anonymous(*get_parameters):
             # If that page is cached the authentication doesn't
             # happen, so we disable the cache when that feature is enabled.
             if (
-                not request.user.is_authenticated and
-                settings.FEATURES.get('ENABLE_CACHE_IF_ANONYMOUS', True)
+                not request.user.is_authenticated
             ):
                 # Use the cache. The same view accessed through different domain names may
                 # return different things, so include the domain name in the key.

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2089,7 +2089,7 @@ def _make_locale_paths_prepend(settings):   # pylint: disable=missing-function-d
         # Add locale paths to settings for comprehensive theming.
         for locale_path in settings.COMPREHENSIVE_THEME_LOCALE_PATHS:
             locale_paths = (path(locale_path), ) + locale_paths
-    return list(locale_paths)
+    return locale_paths
 
 LOCALE_PATHS = _make_locale_paths_prepend
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2082,17 +2082,7 @@ def _make_locale_paths(settings):  # pylint: disable=missing-function-docstring
         for locale_path in settings.COMPREHENSIVE_THEME_LOCALE_PATHS:
             locale_paths += (path(locale_path), )
     return locale_paths
-
-def _make_locale_paths_prepend(settings):   # pylint: disable=missing-function-docstring
-    locale_paths = (settings.REPO_ROOT + '/conf/locale',)  # edx-platform/conf/locale/
-    if settings.ENABLE_COMPREHENSIVE_THEMING:
-        # Add locale paths to settings for comprehensive theming.
-        for locale_path in settings.COMPREHENSIVE_THEME_LOCALE_PATHS:
-            locale_paths = (path(locale_path), ) + locale_paths
-    return locale_paths
-
-LOCALE_PATHS = _make_locale_paths_prepend
-
+LOCALE_PATHS = _make_locale_paths
 derived('LOCALE_PATHS')
 
 # Messages

--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -148,11 +148,6 @@ from common.djangoapps.pipeline_mako import render_require_js_path_overrides
     <meta name="google-site-verification" content="${google_site_verification_id}" />
   % endif
 
-  <% educast_site_id = configuration_helpers.get_value('EDUCAST_SITE_ID', '')%>
-  % if educast_site_id:
-    <meta name="integration" content="${educast_site_id}">
-  % endif
-
   <meta name="openedx-release-line" content="${RELEASE_LINE}" />
 
 <% ga_acct = static.get_value("GOOGLE_ANALYTICS_ACCOUNT", settings.GOOGLE_ANALYTICS_ACCOUNT) %>


### PR DESCRIPTION
## Summary

This PR remove commits no longer useful following this ticket: https://github.com/fccn/nau-technical/issues/394


## Reverts :
- **disable/enable anonymous cache:**
This will be removed because it was incorporated before using Tutor to disable/enable cache in Devstack.

    - commit c77eb41030c8ed1cf4c0a915c648c3c0a368b03f.

- **EDUCAST feature:**
NAU are integrated with educast but it requires that the videos need to be public on the eduCAST itself, they can be hidden on the search eduCAST feature, so it is no longer necessary to authenticate the user and the video.
     - commit be77f0446767abb473e75e24090521f0497b07b3.



- **LOCALE_PATHS:**
This configuration overrides the LOCALE_PATHS order: https://github.com/fccn/nau-kubernetes-manifests/blob/71667b87581ea87d1aca1aa68775ebc51d1f78a7/dev/environments/dev/env/apps/openedx/settings/cms/production.py#L803.
I checked the variable before and after reverse the commits and the output is the same, the override is working.
Commit 1: https://github.com/fccn/edx-platform/commit/9983afea498cd0be18a698d1d65b2150dded4b11
Commit 2: https://github.com/fccn/edx-platform/commit/0580806c86f1c7b986be506f19df2b891be245e4
Before revert:  
    <img width="387" height="92" alt="image" src="https://github.com/user-attachments/assets/515c6b2b-380f-4162-8585-3ccdf891c28c" />
After revert: 
    <img width="362" height="51" alt="image" src="https://github.com/user-attachments/assets/b0c83fcf-1904-4535-8e64-18b1079da567" />

