### PR TITLE
revert: remove extension points to get/update extended profile fields in the account settings

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/api.py
+++ b/openedx/core/djangoapps/user_api/accounts/api.py
@@ -28,7 +28,6 @@ from lms.djangoapps.certificates.api import get_certificates_for_user
 from lms.djangoapps.certificates.data import CertificateStatuses
 
 from openedx.core.djangoapps.enrollments.api import get_verified_enrollments
-from openedx.core.djangoapps.plugins.plugin_extension_points import run_extension_point
 from openedx.core.djangoapps.user_api import accounts, errors, helpers
 from openedx.core.djangoapps.user_api.errors import (
     AccountUpdateError,
@@ -169,13 +168,6 @@ def update_account_settings(requesting_user, update, username=None):
         _store_old_name_if_needed(old_name, user_profile, requesting_user)
         _update_extended_profile_if_needed(update, user_profile)
         _update_state_if_needed(update, user_profile)
-
-        # Allow a plugin to save the updated values
-        run_extension_point(
-            'NAU_STUDENT_ACCOUNT_PARTIAL_UPDATE',
-            update=update,
-            user=user,
-        )
 
     except PreferenceValidationError as err:
         raise AccountValidationError(err.preference_errors)  # lint-amnesty, pylint: disable=raise-missing-from

--- a/openedx/core/djangoapps/user_api/accounts/serializers.py
+++ b/openedx/core/djangoapps/user_api/accounts/serializers.py
@@ -13,6 +13,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.urls import reverse
 from rest_framework import serializers
 
+
 from common.djangoapps.student.models import (
     LanguageProficiency,
     PendingNameChange,
@@ -20,8 +21,6 @@ from common.djangoapps.student.models import (
     UserPasswordToggleHistory,
     UserProfile
 )
-
-from openedx.core.djangoapps.plugins.plugin_extension_points import run_extension_point
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.user_api import errors
 from openedx.core.djangoapps.user_api.accounts.utils import is_secondary_email_feature_enabled
@@ -220,13 +219,6 @@ class UserReadOnlySerializer(serializers.Serializer):  # lint-amnesty, pylint: d
                     "secondary_email_enabled": True,
                 }
             )
-
-        # Append/Override the existing data values with plugin defined values
-        run_extension_point(
-            'NAU_STUDENT_SERIALIZER_CONTEXT_EXTENSION',
-            data=data,
-            user=user,
-        )
 
         if self.custom_fields:
             fields = self.custom_fields

--- a/openedx/core/djangoapps/user_api/accounts/settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/settings_views.py
@@ -26,7 +26,6 @@ from lms.djangoapps.commerce.utils import EcommerceService
 from openedx.core.djangoapps.commerce.utils import get_ecommerce_api_base_url, get_ecommerce_api_client
 from openedx.core.djangoapps.dark_lang.models import DarkLangConfig
 from openedx.core.djangoapps.lang_pref.api import all_languages, released_languages
-from openedx.core.djangoapps.plugins.plugin_extension_points import run_extension_point
 from openedx.core.djangoapps.programs.models import ProgramsApiConfig
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.user_api.accounts.toggles import (
@@ -198,13 +197,6 @@ def account_settings_context(request):
             # in with, or if the user is already authenticated with them.
         } for state in auth_states if state.provider.display_for_login or state.has_account]
 
-    # Append/Override the existing view context values with plugin defined values
-    run_extension_point(
-        'NAU_STUDENT_ACCOUNT_CONTEXT_EXTENSION',
-        context=context,
-        request=request,
-        user=user,
-    )
     return context
 
 


### PR DESCRIPTION
## Description

This reverts commit 3b21ebf0bcd656d817247dd96366db9424f365a5

This PR removes the extension points responsible for retrieving and updating extended profile fields in the account settings.

- `NAU_STUDENT_ACCOUNT_PARTIAL_UPDATE`
- `NAU_STUDENT_SERIALIZER_CONTEXT_EXTENSION`
- `NAU_STUDENT_ACCOUNT_CONTEXT_EXTENSION`

This is made in favor of using upstream changes in edx-platform instead (https://github.com/openedx/edx-platform/pull/37119)

### Related Issues
https://github.com/fccn/nau-technical/issues/394

### Related PRs
- https://github.com/fccn/nau-openedx-extensions/pull/89