### PR TITLE
chore: elimination of running extensions SAML idp classes and choices

### DIFF
--- a/common/djangoapps/third_party_auth/saml.py
+++ b/common/djangoapps/third_party_auth/saml.py
@@ -554,8 +554,7 @@ def get_saml_idp_choices():
         (SAP_SUCCESSFACTORS_SAML_KEY, 'SAP SuccessFactors provider'),
     )
 
-    add_extended_saml_idp_choices = run_extension_point('NAU_ADD_SAML_IDP_CHOICES', choices=choices)
-    return add_extended_saml_idp_choices or choices
+    return choices
 
 
 def get_saml_idp_class(idp_identifier_string):
@@ -567,9 +566,6 @@ def get_saml_idp_class(idp_identifier_string):
         STANDARD_SAML_PROVIDER_KEY: EdXSAMLIdentityProvider,
         SAP_SUCCESSFACTORS_SAML_KEY: SapSuccessFactorsIdentityProvider,
     }
-
-    add_extended_saml_idp_class_choices = run_extension_point('NAU_ADD_SAML_IDP_CLASSES', choices=choices, idp_identifier_string=idp_identifier_string)
-    choices = add_extended_saml_idp_class_choices or choices
 
     if idp_identifier_string not in choices:
         log.error(


### PR DESCRIPTION
Related PR: https://github.com/fccn/nau-openedx-extensions/pull/91
Related Issue: https://github.com/fccn/nau-technical/issues/394
## Summary

This PR removes deprecated custom SAML identity provider extensions from NAU that are redundant with upstream edx-platform functionality. The custom NAU SAML provider has been superseded by the standard upstream implementation.

## Background & Investigation Findings

### Current State Analysis
- **Production Environment**: NAU has not used nau_custom_saml_provider extensions since 2020, every single provider has been settled using Standard SAML Provider since then:

<img width="1408" height="103" alt="image" src="https://github.com/user-attachments/assets/235e1182-12da-411d-ac7f-1fa86d3d0b9f" />

- **Current Usage**: NAU is already using "Standard SAML provider" (upstream implementation)
<img width="442" height="677" alt="image" src="https://github.com/user-attachments/assets/59d6fd7c-1b3e-48ab-8ca3-46efdcf1c19d" />

- **Functionality**: Both approaches provide identical field mapping capabilities, that's why we can remove the extension and use only the upstream way

### Key Discovery
In `/admin/third_party_auth/samlproviderconfig/`, providers can be extended using upstream functionality through the "Advanced Settings" field by defining `extra_field_definitions` - which provides the same functionality as NAU's custom `field_mapping_rules` in [NauEdXSAMLIdentityProvider](https://github.com/fccn/nau-openedx-extensions/blob/da602f988d08e04188a8c2fc3ca77607ea3cc284/nau_openedx_extensions/third_party_auth/providers/saml.py#L33)

## Changes Made

### Removed from `edx-platform`
- ✅ Extension points `NAU_ADD_SAML_IDP_CHOICES` and `NAU_ADD_SAML_IDP_CLASSES` in SAML functions

### Removed from `nau-openedx-extensions`

- ✅ `get_extended_saml_idp_choices()` function
- ✅ `extend_saml_idp_classes()` function  

- ✅ Related settings in `common.py`:
 
  - `NAU_ADD_SAML_IDP_CHOICES`
  - `NAU_ADD_SAML_IDP_CLASSES`


## Migration Guide

### How to:

-  In django admin go to: admin/third_party_auth/samlproviderconfig
- Create a new provider config
- Fill out the form based on your needs
- Identity Provider Type: Standar SAML Provider
- Add your custom fields definitions In advanced settings. Example:
<img width="1436" height="286" alt="image" src="https://github.com/user-attachments/assets/8d89dc62-f1d8-4484-b929-44d6cd826a46" />

