### PR TITLE
feat: add user certificate to Certificate render start context

### DIFF
--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -597,6 +597,9 @@ def render_html_view(request, course_id, certificate=None):  # pylint: disable=t
             certificate_language=certificate_language,
         )
 
+        # NAU Customization so the filter know which certificate is being rendered
+        context['user_certificate'] = user_certificate
+
         # Append/Override the existing view context values with any course-specific static values from Advanced Settings
         context.update(course.cert_html_view_overrides)
 


### PR DESCRIPTION
Add the user certificate to the CertificateRenderStarted Open edX filter context, so it is possible to have complex filtering and applying
custom logic to the course certificate presentation.

fccn/nau-technical#667
