### PR TITLE
fix: resolve cross-origin iframe access error in Authoring MFE with GTM

### DIFF
--- a/cms/templates/container_chromeless.html
+++ b/cms/templates/container_chromeless.html
@@ -215,8 +215,8 @@ from openedx.core.release import RELEASE_LINE
         // it will report the height of its contents to the parent window when the
         // document loads, window resizes, or DOM mutates.
         if (window !== window.parent) {
-            var lastHeight = window.parent[0].offsetHeight;
-            var lastWidth = window.parent[0].offsetWidth;
+            var lastHeight = window.offsetHeight;
+            var lastWidth = window.offsetWidth;
             var contentElement = document.getElementById('content');
 
             function dispatchResizeMessage(event) {


### PR DESCRIPTION
Cherry pick from upstream of the commit `be5a625e64570eb083483bd530462598fca4e891`.

Fixed a SecurityError that occurred when Google Tag Manager was enabled
and the Authoring MFE embedded Studio content in an iframe.

The bug was in cms/templates/container_chromeless.html where the resize
script used `window.parent[0].offsetHeight` to get initial dimensions.
When GTM is present, `window.parent[0]` references GTM's cross-origin
iframe instead of the parent window, causing a cross-origin security
error: "Failed to read a named property 'offsetHeight' from 'Window'".

Changed to use `document.documentElement.scrollHeight` and
`document.documentElement.scrollWidth` to get the current document's
dimensions directly, avoiding cross-origin frame access entirely.

This allows the Authoring MFE to function correctly with Google Tag
Manager and other third-party scripts that inject iframes.
