### PR TITLE
refactor: Extract get_additional_student_profile_attributes function

### DIFF
--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -1493,10 +1493,7 @@ class GetStudentsFeatures(DeveloperErrorViewMixin, APIView):
                 'enrollment_date',
             ]
 
-        additional_attributes = configuration_helpers.get_value_for_org(
-            course_key.org,
-            "additional_student_profile_attributes"
-        )
+        additional_attributes = instructor_analytics_basic.get_additional_student_profile_attributes(course_key)
         if additional_attributes:
             # Fail fast: must be list/tuple of strings.
             if not isinstance(additional_attributes, (list, tuple)):

--- a/lms/djangoapps/instructor_analytics/basic.py
+++ b/lms/djangoapps/instructor_analytics/basic.py
@@ -141,15 +141,33 @@ def get_student_features_with_custom(course_key):
     Returns:
         tuple: Combined tuple of standard STUDENT_FEATURES and custom attributes
     """
-    additional_attributes = configuration_helpers.get_value_for_org(
-        course_key.org,
-        "additional_student_profile_attributes"
-    )
+    additional_attributes = get_additional_student_profile_attributes(course_key)
 
     if additional_attributes:
         return STUDENT_FEATURES + tuple(additional_attributes)
 
     return STUDENT_FEATURES
+
+
+def get_additional_student_profile_attributes(course_key):
+    """
+    Return list of additional student profile attributes configured for the course organization.
+
+    This function retrieves any custom student profile attributes that have been configured for
+    a specific course organization. These attributes can be used to extend the standard set of
+    student features included in analytics exports.
+
+    Args:
+        course_key: CourseKey object for the course
+
+    Returns:
+        list: List of additional student profile attributes configured for the course organization
+    """
+    return configuration_helpers.get_value_for_org(
+        course_key.org,
+        "additional_student_profile_attributes",
+        default=[]
+    )
 
 
 def get_available_features(course_key):


### PR DESCRIPTION
Extract the configuration_helpers.get_value_for_org() call for fetching additional student profile attributes into a dedicated function to eliminate code duplication between instructor_analytics.basic and instructor.views.api.

fccn/nau-technical#797