### PR TITLE
fix: restore get_certificates_for_course_and_users missing from teak …

### DIFF
--- a/lms/djangoapps/certificates/api.py
+++ b/lms/djangoapps/certificates/api.py
@@ -933,6 +933,20 @@ def invalidate_certificate(user_id, course_key_or_id, source):
     return True
 
 
+def get_certificates_for_course_and_users(course_id, users):
+    """
+    Retrieves all GeneratedCertificate records for a specific course and a list of users.
+
+    Args:
+        course_id (CourseKey): The unique identifier for the course run.
+        users (Iterable[User]): A list or queryset of User instances to filter certificates by.
+
+    Returns:
+        QuerySet[GeneratedCertificate]: A queryset containing the matching certificate records.
+    """
+    return GeneratedCertificate.objects.filter(course_id=course_id, user__in=users)
+
+
 def clear_pii_from_certificate_records_for_user(user):
     """
     Utility function to remove PII from certificate records when a learner's account is being retired. Used by the

--- a/lms/djangoapps/instructor_task/tasks_helper/grades.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/grades.py
@@ -23,6 +23,7 @@ from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.roles import BulkRoleCache
 from lms.djangoapps.certificates import api as certs_api
+from lms.djangoapps.certificates.api import get_certificates_for_course_and_users
 from lms.djangoapps.course_blocks.api import get_course_block_access_transformers, get_course_blocks
 from lms.djangoapps.course_blocks.transformers import library_content
 from lms.djangoapps.courseware.user_state_client import DjangoXBlockUserStateClient
@@ -244,7 +245,7 @@ class _CertificateBulkContext:
         self.certificates_by_user = {
             certificate.user.id: certificate
             for certificate in
-            GeneratedCertificate.objects.filter(course_id=context.course_id, user__in=users)
+            get_certificates_for_course_and_users(course_id=context.course_id, users=users)
         }
 
 


### PR DESCRIPTION
# fix: restore get_certificates_for_course_and_users missing from teak fork

## Problem

The backport of [openedx/edx-platform#36677](https://github.com/openedx/openedx-platform/pull/36677) to `nau/teak.master` removed the `GeneratedCertificate` import from `grades.py` — expecting `get_certificates_for_course_and_users` to already exist in `lms/djangoapps/certificates/api.py`. However, the teak fork did not have that function, leaving `_CertificateBulkContext` referencing an undefined name.

This caused all grade report generation to fail with:

```
NameError: name 'GeneratedCertificate' is not defined
  File "/openedx/edx-platform/lms/djangoapps/instructor_task/tasks_helper/grades.py", line 247, in __init__
    GeneratedCertificate.objects.filter(course_id=context.course_id, user__in=users)
```

## Solution

Two files changed:

**`lms/djangoapps/certificates/api.py`**
Added `get_certificates_for_course_and_users(course_id, users)` — identical to the upstream implementation. Wraps `GeneratedCertificate.objects.filter(...)` behind a clean API function.

**`lms/djangoapps/instructor_task/tasks_helper/grades.py`**
- Added `from lms.djangoapps.certificates.api import get_certificates_for_course_and_users`
- Updated `_CertificateBulkContext.__init__` to call the new function instead of querying `GeneratedCertificate` directly

This aligns the fork with the current upstream approach (option 1 as discussed in the issue thread)
