### PR TITLE
fix: additional attributes fallback in report csv to site config when…

### DIFF
--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -1497,6 +1497,10 @@ class GetStudentsFeatures(DeveloperErrorViewMixin, APIView):
             course_key.org,
             "additional_student_profile_attributes"
         )
+        if not additional_attributes:
+            additional_attributes = configuration_helpers.get_value(
+                "additional_student_profile_attributes", []
+            )
         if additional_attributes:
             # Fail fast: must be list/tuple of strings.
             if not isinstance(additional_attributes, (list, tuple)):
@@ -1521,7 +1525,7 @@ class GetStudentsFeatures(DeveloperErrorViewMixin, APIView):
                         attrs=', '.join(invalid)
                     )
                 )
-            query_features.extend(additional_attributes)
+            query_features.extend([a for a in additional_attributes if a not in query_features])
 
         # Provide human-friendly and translatable names for these features. These names
         # will be displayed in the table generated in data_download.js. It is not (yet)
@@ -1552,7 +1556,7 @@ class GetStudentsFeatures(DeveloperErrorViewMixin, APIView):
                     # pylint: disable-next=translation-of-non-string
                     query_features_names[attr] = _(formatted_name)
 
-        for field in settings.PROFILE_INFORMATION_REPORT_PRIVATE_FIELDS:
+        for field in getattr(settings, 'PROFILE_INFORMATION_REPORT_PRIVATE_FIELDS', []):
             keep_field_private(query_features, field)
             query_features_names.pop(field, None)
 

--- a/lms/djangoapps/instructor_analytics/basic.py
+++ b/lms/djangoapps/instructor_analytics/basic.py
@@ -146,6 +146,11 @@ def get_student_features_with_custom(course_key):
         "additional_student_profile_attributes"
     )
 
+    if not additional_attributes:
+        additional_attributes = configuration_helpers.get_value(
+            "additional_student_profile_attributes", []
+        )
+
     if additional_attributes:
         return STUDENT_FEATURES + tuple(additional_attributes)
 


### PR DESCRIPTION
Related issue: https://github.com/fccn/nau-technical/issues/862

--- 

## Summary

The Teak upgrade introduced a breaking change ([PR #37264](https://github.com/openedx/edx-platform/pull/37264)) that replaced the `STUDENT_PROFILE_DOWNLOAD_FIELDS_CUSTOM_STUDENT_ATTRIBUTES` Django settings fallback with a `get_value_for_org()` lookup requiring a matching `course_org_filter` in the site configuration. Since NAU's site configuration has no `course_org_filter`, custom attributes (`nau_nif`, `nau_user_extended_model_cc_nic`, `nau_user_extended_model_employment_situation`) were never extracted from the User model, leaving those columns empty in the CSV and causing a column shift where `city` and `country` values appeared under the NIF/CC headers.

This fix adds a site-level fallback using `get_value("additional_student_profile_attributes")` in both `instructor_analytics/basic.py` (`get_student_features_with_custom`) and `instructor/views/api.py` (the profile download endpoint). When no org-specific configuration is found, the site-wide value is used instead, making custom attributes work without requiring `course_org_filter`. Additionally, `query_features.extend()` is guarded against duplicates to avoid double columns when the fields are already listed in `student_profile_download_fields`.

## Changes

- **`lms/djangoapps/instructor_analytics/basic.py`**: Added site-level fallback in `get_student_features_with_custom()` when `get_value_for_org()` returns empty.
- **`lms/djangoapps/instructor/views/api.py`**: Added the same site-level fallback for `additional_student_profile_attributes` and prevented duplicate columns with a deduplication guard on `query_features.extend()`.

## Configuration required

Add `additional_student_profile_attributes` to the site configuration (no `course_org_filter` needed):

```json
"additional_student_profile_attributes": [
    "nau_user_extended_model_cc_nic",
    "nau_nif",
    "nau_user_extended_model_employment_situation"
]