### PR TITLE
fix: celery-worker now receives context from http request for csv reports

### DIFF
--- a/lms/djangoapps/instructor_analytics/basic.py
+++ b/lms/djangoapps/instructor_analytics/basic.py
@@ -301,7 +301,7 @@ def enrolled_students_features(course_key, features):
 
     students = [enrollment.user for enrollment in enrollments]
 
-    student_features = [x for x in get_student_features_with_custom(course_key) if x in features]
+    student_features = [x for x in features if x not in set(PROFILE_FEATURES) and 'meta.' not in x]
     profile_features = [x for x in PROFILE_FEATURES if x in features]
 
     if 'external_user_key' in features and len(students) > 0:


### PR DESCRIPTION
Related issue: https://github.com/fccn/nau-technical/issues/862

---

`enrolled_students_features()` was recomputing the list of student fields by calling `get_student_features_with_custom()` inside the Celery task, which relies on `get_current_request()` to resolve the site configuration. Since Celery workers have no HTTP request context, `configuration_helpers.get_value()` always returned the default empty list, causing custom attributes (e.g. `nau_nif`) to be absent from the student dict while still present in the CSV header — resulting in misaligned columns. The fix uses the `features` parameter directly (already computed correctly during the HTTP request and serialized into the task input) instead of re-querying site config in the wrong context.