### PR TITLE
fix: surface EnrollmentNotAllowed message to instructor dashboard

### DIFF
--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -67,6 +67,7 @@ from common.djangoapps.student.models import (
     get_user_by_username_or_email,
     is_email_retired,
 )
+from common.djangoapps.student.models.course_enrollment import EnrollmentNotAllowed
 from common.djangoapps.student.roles import CourseFinanceAdminRole, CourseSalesAdminRole
 from common.djangoapps.util.file import (
     FileValidationException,
@@ -836,6 +837,16 @@ def students_update_enrollment(request, course_id):  # lint-amnesty, pylint: dis
             # validity (obviously, cannot check if email actually /exists/,
             # simply that it is plausibly valid)
             validate_email(email)  # Raises ValidationError if invalid
+        except ValidationError:
+            # Flag this email as an error if invalid, but continue checking
+            # the remaining in the list
+            results.append({
+                'identifier': identifier,
+                'invalidIdentifier': True,
+            })
+            continue
+
+        try:
             if action == 'enroll':
                 before, after, enrollment_obj = enroll_email(
                     course_id, email, auto_enroll, email_students, {**email_params}, language=language
@@ -880,12 +891,25 @@ def students_update_enrollment(request, course_id):  # lint-amnesty, pylint: dis
                     f"Unrecognized action '{action}'"
                 ))
 
-        except ValidationError:
-            # Flag this email as an error if invalid, but continue checking
-            # the remaining in the list
+        except EnrollmentNotAllowed as exc:
+            # Enrollment was blocked by a pipeline filter (e.g. NIF requirement).
+            # Surface the specific message so the instructor knows the reason.
+            log.warning("Enrollment not allowed for %s: %s", identifier, exc)
             results.append({
                 'identifier': identifier,
-                'invalidIdentifier': True,
+                'error': True,
+                'error_message': str(exc),
+            })
+
+        except ValidationError as exc:
+            # ValidationError raised during enrollment (e.g. pre_save guard blocking
+            # CourseEnrollmentAllowed creation for a NIF-required course).
+            # Surface the specific message so the instructor knows the reason.
+            log.warning("ValidationError while enrolling %s: %s", identifier, exc)
+            results.append({
+                'identifier': identifier,
+                'error': True,
+                'error_message': exc.messages[0] if exc.messages else str(exc),
             })
 
         except Exception as exc:  # pylint: disable=broad-except


### PR DESCRIPTION
# fix: surface EnrollmentNotAllowed message to instructor dashboard

## Problem

When a course has a pipeline filter that blocks enrollment (e.g. `FilterEnrollmentRequireNIF` from `nau-openedx-extensions`), the specific error message was never shown to the instructor. Instead, the instructor saw a generic error with no explanation.

Two cases were affected in `students_update_enrollment`:

1. **Registered user without NIF** — `enroll_email()` raises `EnrollmentNotAllowed` with the specific message (e.g. "É necessário associar a Autenticação Gov..."), which was caught by the broad `except Exception` handler and discarded.

2. **Unregistered user email on a NIF-required course** — a `pre_save` signal guard raises `ValidationError` with a descriptive message, which was caught by the `except ValidationError` handler but returned as `invalidIdentifier: True` — completely misleading for the instructor.

## Solution

- Separated `validate_email` into its own `try/except` block so email format errors are handled independently from enrollment errors.
- Added `except EnrollmentNotAllowed as exc` before the broad `except Exception` to capture and surface `str(exc)` in the response under `error_message`.
- Added `except ValidationError as exc` for `ValidationError` raised during the enrollment process itself, also surfacing the message via `exc.messages[0]`.

## Related

- nau-openedx-extensions PR #145 — adds the `pre_save` guard on `CourseEnrollmentAllowed` and the `FilterEnrollmentRequireNIF` pipeline step that raise these exceptions.
- fccn/nau-technical#771
