### PR TITLE
fix: prevent XBlock container crash when JS resources are blocked by browser extensions

### DIFF
--- a/cms/static/js/views/pages/container.js
+++ b/cms/static/js/views/pages/container.js
@@ -178,7 +178,9 @@ function($, _, Backbone, gettext, BasePage,
                         document.getElementById(data.payload.locator)?.scrollIntoView({behavior: "smooth"});
                         break;
                     default:
-                        console.warn('Unhandled message type:', data.type);
+                        if (data.type) {
+                            console.warn('Unhandled message type:', data.type);
+                        }
                     }
                 });
             }

--- a/cms/static/js/views/xblock.js
+++ b/cms/static/js/views/xblock.js
@@ -58,7 +58,7 @@ function($, _, ViewUtils, BaseView, XBlock, HtmlUtils) {
                 aside;
 
             fragmentsRendered = this.renderXBlockFragment(fragment, wrapper);
-            fragmentsRendered.always(function() {
+            fragmentsRendered.done(function() {
                 xblockElement = self.$('.xblock').first();
                 try {
                     xblock = XBlock.initializeBlock(xblockElement);
@@ -180,13 +180,16 @@ function($, _, ViewUtils, BaseView, XBlock, HtmlUtils) {
             var self = this,
                 applyResource,
                 numResources,
-                deferred;
+                deferred,
+                failedJs = false;
             numResources = resources.length;
             deferred = $.Deferred();
             applyResource = function(index) {
                 var hash, resource, value, promise;
                 if (index >= numResources) {
-                    deferred.resolve();
+                    deferred.resolve({
+                        failedJs: failedJs
+                    });
                     return;
                 }
                 value = resources[index];
@@ -194,6 +197,19 @@ function($, _, ViewUtils, BaseView, XBlock, HtmlUtils) {
                 if (!window.loadedXBlockResources) {
                     window.loadedXBlockResources = [];
                 }
+                if (!window.failedXBlockResources) {
+                    window.failedXBlockResources = [];
+                }
+                // A JS resource that previously failed (e.g., blocked by an extension):
+                // mark failedJs so the specific XBlock that needs it gets skipped,
+                // but continue loading the rest of the fragment's resources so that
+                // other XBlocks in the same fragment are not affected.
+                if (_.indexOf(window.failedXBlockResources, hash) >= 0) {
+                    failedJs = true;
+                    applyResource(index + 1);
+                    return;
+                }
+
                 if (_.indexOf(window.loadedXBlockResources, hash) < 0) {
                     resource = value[1];
                     promise = self.loadResource(resource);
@@ -201,8 +217,24 @@ function($, _, ViewUtils, BaseView, XBlock, HtmlUtils) {
                     promise.done(function() {
                         applyResource(index + 1);
                     }).fail(function() {
-                        deferred.reject();
+                        console.warn(
+                            'Failed to load XBlock resource:',
+                            resource.data || resource.kind
+                        );
+
+                        if (resource.mimetype === 'application/javascript') {
+                            failedJs = true;
+
+                            // Remember this hash so subsequent fragments that reference
+                            // the same resource skip it without a network round-trip.
+                            window.failedXBlockResources.push(hash);
+                        }
+
+                        // Always continue — other resources in this fragment may belong
+                        // to unrelated XBlocks and must still be loaded.
+                        applyResource(index + 1);
                     });
+
                 } else {
                     applyResource(index + 1);
                 }
@@ -235,7 +267,20 @@ function($, _, ViewUtils, BaseView, XBlock, HtmlUtils) {
                     // xss-lint: disable=javascript-jquery-append,javascript-concat-html
                     $head.append('<script>' + data + '</script>');
                 } else if (kind === 'url') {
-                    return ViewUtils.loadJavaScript(data);
+                    // Use a raw <script> tag instead of ViewUtils.loadJavaScript because
+                    // the underlying $script (scriptjs) library invokes its callback on
+                    // both onload AND onerror, making it impossible to detect blocked
+                    // resources (e.g. from browser extensions). A raw tag fires onerror
+                    // only on genuine network failure, letting addXBlockFragmentResources
+                    // track failedJs correctly.
+                    var scriptDeferred = $.Deferred();
+                    var scriptEl = document.createElement('script');
+                    scriptEl.type = 'text/javascript';
+                    scriptEl.src = data;
+                    scriptEl.onload = function() { scriptDeferred.resolve(); };
+                    scriptEl.onerror = function() { scriptDeferred.reject(); };
+                    $head[0].appendChild(scriptEl);
+                    return scriptDeferred.promise();
                 }
             } else if (mimetype === 'text/html') {
                 if (placement === 'head') {

--- a/common/static/common/js/xblock/core.js
+++ b/common/static/common/js/xblock/core.js
@@ -61,6 +61,13 @@
             block = (function() {
                 var initFn = window[$element.data('init')];
 
+                // initFn can be undefined when its JS was blocked (e.g. by an ad-blocker).
+                // Return null so the caller can fall back gracefully instead of crashing.
+                if (!initFn) {
+                    console.warn('XBlock init function not found:', $element.data('init'));
+                    return null;
+                }
+
                 // This create a new constructor that can then apply() the block_args
                 // to the initFn.
                 function Block() {
@@ -70,6 +77,14 @@
 
                 return new Block();
             }());
+
+            if (!block) {
+                $element.trigger('xblock-initialized');
+                $element.data('initialized', true);
+                $element.addClass('xblock-initialized xblock-initialization-failed');
+                return {element: element, name: $element.data('name'), type: $element.data('block-type')};
+            }
+
             block.runtime = runtime;
         } else {
             block = {};


### PR DESCRIPTION
> [!NOTE]
> This fix is intentionally scoped to NAU's fork targeting the `teak` release. It is **not** being submitted upstream because the issue no longer reproduces on `master` (Verawood), meaning the upstream codebase is already clean of this bug — likely resolved as a side effect of broader refactors between releases.

Fixes https://github.com/fccn/nau-technical/issues/838

Fixes a resilience bug in Studio's XBlock container page where Chrome extensions (e.g. AdBlock) that block certain JS resources cause an infinite loading spinner and crash the entire unit — preventing all XBlocks from rendering, not just the one whose resource was blocked.

**Root cause analysis:**

When any JS resource fails to load, `addXBlockFragmentResources` called `deferred.reject()` — and since `renderXBlockFragment` only hooks `.done()`, the XBlock HTML was never injected into the page. The server always sends the spinner as initial HTML; JavaScript is responsible for replacing it. With JS blocked, the spinner stayed forever.

For the Drag & Drop v2 XBlock specifically, AdBlock filter lists target these two scripts by filename pattern:
- `drag_and_drop_v2/public/js/vendor/virtual-dom-*.js`
- `drag_and_drop_v2/public/js/drag_and_drop.*.js`

Both are served from the same domain (no CDN), so there is no cross-origin workaround available.

**Four root causes fixed:**

1. **`loadResource` used `ViewUtils.loadJavaScript` (backed by `$script`/scriptjs)**, which invokes its callback on both `onload` and `onerror`. When AdBlock blocks a script, the promise always resolved — making failures invisible to the application. Fixed by replacing it with a raw `<script>` element that wires `onerror → reject` directly.

2. **`addXBlockFragmentResources` rejected the deferred on first JS failure**, which prevented `renderXBlockFragment`'s `.done()` handler from running — so the XBlock HTML was never injected and the spinner persisted. Fixed by resolving the deferred with a `{failedJs: true}` flag instead of rejecting, so the HTML is always injected regardless of whether the JS loaded. A `window.failedXBlockResources` cache (mirroring the existing `window.loadedXBlockResources` pattern) prevents redundant network requests for known-blocked resources on subsequent XBlock renders within the same page session.

3. **`constructBlock` in `core.js` crashed with `TypeError` when an XBlock's `initFn` was undefined** (because its JS never loaded). The crash propagated to the outer `try/catch` in `handleXBlockFragment`, which called `errorCallback()` instead of `successCallback()` — leaving the container stuck. Fixed with a null check: if `initFn` is missing, the affected XBlock is marked with `xblock-initialization-failed` and a stub is returned, allowing the rest of the vertical to initialize normally. Additionally, `fragmentsRendered.always()` was changed to `.done()` so that XBlock initialization is only attempted when the fragment rendered successfully.

4. **`container.js` message handler logged a spurious warning loop** for every `postMessage` event with `type: undefined` sent by browser extension proxies (e.g. Redux DevTools) via `setInterval`. Fixed by only logging for defined, unrecognized message types.

**Behavior after this fix:**

- XBlocks whose JS resources are blocked render their HTML and receive the `xblock-initialization-failed` CSS class. Their JS is not initialized, so interactive behavior is unavailable — but the block is visible and does not crash the page.
- All other XBlocks in the same unit are completely unaffected.
- A `console.warn` is emitted for each blocked resource and each skipped init function, replacing the previous silent freeze.

**Before:** Chrome + AdBlock → infinite spinner, `TypeError: Cannot read properties of undefined (reading 'prototype')`, all XBlocks in the unit broken.

**After:** Chrome + AdBlock → affected XBlock shows its server-rendered HTML with `xblock-initialization-failed`, all other XBlocks render and initialize normally, no JS crash.

## Testing instructions

**Prerequisites:** A Studio unit with a **Drag & Drop v2** XBlock alongside at least one other XBlock (e.g. Problem/Single Select).

1. We'll test this in `dev` environment using `nau-tutor-configs`: run the environment with the command `bin/tutor dev start`
2. Open Studio and navigate to a unit with a Drag & Drop v2 XBlock and some more XBlocks
3. Block the URLs manually through the dev tools of the browser, and you'll be able to replicate the bug like this
    
    <img width="1879" height="1132" alt="image" src="https://github.com/user-attachments/assets/b581e115-8301-4fd7-8e15-d09a524c9c85" />

4. Change the `edx-platform` branch to this PR, enter the container by running `bin/tutor dev exec cms bash` and compile the assets running `npm run webpack-dev` in the container
5. Fixed!

    <img width="1869" height="1135" alt="image" src="https://github.com/user-attachments/assets/b647b1cc-5773-4b9b-a58c-089b4687236f" />


